### PR TITLE
Feature/UtilUnlit

### DIFF
--- a/cfg/system.config.in
+++ b/cfg/system.config.in
@@ -40,6 +40,7 @@ nm               = @NmCmd@
 objdump          = @ObjdumpCmd@
 ranlib           = @REAL_RANLIB_CMD@
 tar              = @TarCmd@
+perl             = @PerlCmd@
 
 # Information about builders:
 #============================

--- a/shaking-up-ghc.cabal
+++ b/shaking-up-ghc.cabal
@@ -91,6 +91,7 @@ executable ghc-shake
                        , Settings.Packages.Rts
                        , Settings.Packages.RunGhc
                        , Settings.Packages.Touchy
+                       , Settings.Packages.Unlit                       
                        , Settings.TargetDirectory
                        , Settings.User
                        , Settings.Ways

--- a/shaking-up-ghc.cabal
+++ b/shaking-up-ghc.cabal
@@ -47,6 +47,7 @@ executable ghc-shake
                        , Rules.Generators.GhcAutoconfH
                        , Rules.Generators.GhcBootPlatformH
                        , Rules.Generators.GhcPlatformH
+                       , Rules.Generators.GhcSplit
                        , Rules.Generators.GhcVersionH
                        , Rules.Generators.VersionHs
                        , Rules.IntegerGmp
@@ -91,7 +92,7 @@ executable ghc-shake
                        , Settings.Packages.Rts
                        , Settings.Packages.RunGhc
                        , Settings.Packages.Touchy
-                       , Settings.Packages.Unlit                       
+                       , Settings.Packages.Unlit
                        , Settings.TargetDirectory
                        , Settings.User
                        , Settings.Ways

--- a/src/Builder.hs
+++ b/src/Builder.hs
@@ -41,6 +41,7 @@ data Builder = Alex
              | Ld
              | Nm
              | Objdump
+             | Perl
              | Ranlib
              | Tar
              | Unlit
@@ -83,6 +84,7 @@ builderKey builder = case builder of
     Ld               -> "ld"
     Nm               -> "nm"
     Objdump          -> "objdump"
+    Perl             -> "perl"
     Ranlib           -> "ranlib"
     Tar              -> "tar"
     Unlit            -> "unlit"

--- a/src/GHC.hs
+++ b/src/GHC.hs
@@ -6,7 +6,7 @@ module GHC (
     haddock, haskeline, hsc2hs, hoopl, hp2ps, hpc, hpcBin, integerGmp,
     integerSimple, iservBin, libffi, mkUserGuidePart, parallel, pretty,
     primitive, process, rts, runGhc, stm, templateHaskell, terminfo, time,
-    touchy, transformers, unix, win32, xhtml,
+    touchy, transformers, unlit, unix, win32, xhtml,
 
     defaultKnownPackages, defaultTargetDirectory, defaultProgramPath
     ) where
@@ -28,7 +28,7 @@ defaultKnownPackages =
     , ghcTags, haddock, haskeline, hsc2hs, hoopl, hp2ps, hpc, hpcBin, integerGmp
     , integerSimple, iservBin, libffi, mkUserGuidePart, parallel, pretty
     , primitive, process, rts, runGhc, stm, templateHaskell, terminfo, time
-    , touchy, transformers, unix, win32, xhtml ]
+    , touchy, transformers, unlit, unix, win32, xhtml ]
 
 -- Package definitions (see "Package")
 array, base, binary, bytestring, cabal, compiler, containers, compareSizes,
@@ -37,7 +37,7 @@ array, base, binary, bytestring, cabal, compiler, containers, compareSizes,
     haddock, haskeline, hsc2hs, hoopl, hp2ps, hpc, hpcBin, integerGmp,
     integerSimple, iservBin, libffi, mkUserGuidePart, parallel, pretty,
     primitive, process, rts, runGhc, stm, templateHaskell, terminfo, time,
-    touchy, transformers, unix, win32, xhtml :: Package
+    touchy, transformers, unlit, unix, win32, xhtml :: Package
 
 array           = library  "array"
 base            = library  "base"
@@ -85,11 +85,12 @@ terminfo        = library  "terminfo"
 time            = library  "time"
 touchy          = utility  "touchy"
 transformers    = library  "transformers"
+unlit           = utility  "unlit"
 unix            = library  "unix"
 win32           = library  "Win32"
 xhtml           = library  "xhtml"
 
--- TODO: The following utils are not implemented yet: unlit, driver/ghc-split
+-- TODO: The following utils are not implemented yet: driver/ghc-split
 -- TODO: The following utils are not included into the build system because
 -- they seem to be unused or unrelated to the build process: checkUniques,
 -- completion, count_lines, coverity, debugNGC, describe-unexpected, genargs,
@@ -112,8 +113,11 @@ defaultProgramPath stage pkg
     | pkg == haddock || pkg == ghcTags = case stage of
         Stage2 -> Just . inplaceProgram $ pkgNameString pkg
         _      -> Nothing
-    | pkg == touchy = case stage of
+    |  pkg == touchy = case stage of
         Stage0 -> Just $ "inplace/lib/bin" -/- pkgNameString pkg <.> exe
+        _      -> Nothing
+    | pkg == unlit = case stage of
+        Stage0 -> Just $ "inplace/lib" -/- pkgNameString pkg <.> exe
         _      -> Nothing
     | isProgram pkg = case stage of
         Stage0 -> Just . inplaceProgram $ pkgNameString pkg

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -19,6 +19,7 @@ main = shakeArgs options rules
         , Rules.Config.configRules
         , Rules.Generate.copyRules
         , Rules.Generate.generateRules
+        , Rules.Generate.generateScripts
         , Rules.generateTargets
         , Rules.IntegerGmp.integerGmpRules
         , Rules.Libffi.libffiRules

--- a/src/Rules/Data.hs
+++ b/src/Rules/Data.hs
@@ -67,6 +67,17 @@ buildPackageData rs target @ (PartialTarget stage pkg) = do
             writeFileChanged mk contents
             putSuccess $ "| Successfully generated '" ++ mk ++ "'."
 
+        when (pkg == unlit) $ dataFile %> \mk -> do
+            let prefix  = "utils_unlit_" ++ stageString stage ++ "_"
+                contents = unlines $ map (prefix++)
+                    [ "PROGNAME = unlit"
+                    , "C_SRCS = unlit.c"
+                    , "INSTALL = YES"
+                    , "INSTALL_INPLACE = YES"
+                    , "SYNOPSIS = Literate script filter." ]
+            writeFileChanged mk contents
+            putSuccess $ "| Successfully generated '" ++ mk ++ "'."
+
         when (pkg == touchy) $ dataFile %> \mk -> do
             let prefix = "utils_touchy_" ++ stageString stage ++ "_"
                 contents = unlines $ map (prefix++)

--- a/src/Rules/Generators/GhcSplit.hs
+++ b/src/Rules/Generators/GhcSplit.hs
@@ -1,0 +1,25 @@
+module Rules.Generators.GhcSplit (generateGhcSplit) where
+
+import Base
+import Expression
+import Oracles
+import Settings.User
+
+generateGhcSplit :: Expr String
+generateGhcSplit = do
+    let yesNo = lift . fmap (\x -> if x then "YES" else "NO")
+    perl <- getBuilderPath Perl
+    let script = "driver" -/- "split" -/- "ghc-split.prl"
+    when trackBuildSystem . lift $
+        need [sourcePath -/- "Rules" -/- "Generators" -/- "GhcSplit.hs"]
+    lift $ need [script]
+    targetPlatform <- getSetting TargetPlatform
+    ghcEnableTNC   <- yesNo ghcEnableTablesNextToCode
+    contents       <- lift $ readFileLines script
+    return . unlines $
+        [ "#!" ++ perl
+        , "$TARGETPLATFORM = \"" ++ targetPlatform ++ "\";"
+        -- I don't see where the ghc-split tool uses TNC, but
+        -- it's in the build-perl macro.
+        , "$TABLES_NEXT_TO_CODE = \"" ++ ghcEnableTNC ++ "\";"
+        ] ++ contents

--- a/src/Settings/Args.hs
+++ b/src/Settings/Args.hs
@@ -31,6 +31,7 @@ import Settings.Packages.IservBin
 import Settings.Packages.Rts
 import Settings.Packages.RunGhc
 import Settings.Packages.Touchy
+import Settings.Packages.Unlit
 import Settings.User
 
 getArgs :: Expr [String]
@@ -77,4 +78,5 @@ defaultPackageArgs = mconcat
     , iservBinPackageArgs
     , rtsPackageArgs
     , runGhcPackageArgs
-    , touchyPackageArgs ]
+    , touchyPackageArgs
+    , unlitPackageArgs ]

--- a/src/Settings/Packages/Unlit.hs
+++ b/src/Settings/Packages/Unlit.hs
@@ -1,0 +1,16 @@
+module Settings.Packages.Unlit (unlitPackageArgs) where
+
+import Base
+import Expression
+import GHC (unlit)
+import Predicates (builderGhc, package)
+import Settings (getTargetPath)
+
+unlitPackageArgs :: Args
+unlitPackageArgs = package unlit ? do
+    path <- getTargetPath
+    let cabalMacros = path -/- "build/autogen/cabal_macros.h"
+    mconcat [ builderGhc ?
+              mconcat [ arg "-no-hs-main"
+                      , remove ["-hide-all-packages"]
+                      , removePair "-optP-include" $ "-optP" ++ cabalMacros ] ]

--- a/src/Settings/User.hs
+++ b/src/Settings/User.hs
@@ -9,6 +9,7 @@ module Settings.User (
 import GHC
 import Expression
 import Predicates
+import Settings.Default
 
 -- Control user-specific settings
 userArgs :: Args
@@ -59,7 +60,7 @@ validating = False
 
 -- To switch off split objects change to 'return False'
 splitObjects :: Predicate
-splitObjects = return False -- FIXME: should be defaultSplitObjects, see #84.
+splitObjects = defaultSplitObjects
 
 dynamicGhcPrograms :: Bool
 dynamicGhcPrograms = False


### PR DESCRIPTION
Fixes #82, #83, and #84.

But I’m running into an issue with the split objs.

```
/usr/bin/ar: createProcess: runInteractiveProcess: exec: resource exhausted (Argument list too long))
```

I’m also fairly certain this needs some adaptations for Windows.

I’ll leave this here for review.